### PR TITLE
Minor improvements

### DIFF
--- a/mode-line-bell.el
+++ b/mode-line-bell.el
@@ -29,6 +29,9 @@
 (defvar mode-line-bell-flashing nil
   "If non-nil, the mode line is currently flashing.")
 
+(defvar mode-line-bell-flash-time 0.05
+  "Length of time to flash the mode line when the bell is rung.")
+
 (defun mode-line-bell-begin-flash ()
   "Begin flashing the mode line."
   (unless mode-line-bell-flashing
@@ -45,7 +48,7 @@
 (defun mode-line-bell-flash ()
   "Flash the mode line momentarily."
   (unless mode-line-bell-flashing
-    (run-with-timer 0.05 nil 'mode-line-bell-end-flash)
+    (run-with-timer mode-line-bell-flash-time nil 'mode-line-bell-end-flash)
     (mode-line-bell-begin-flash)))
 
 ;;;###autoload

--- a/mode-line-bell.el
+++ b/mode-line-bell.el
@@ -26,12 +26,27 @@
 
 ;;; Code:
 
+(defvar mode-line-bell-flashing nil
+  "If non-nil, the mode line is currently flashing.")
+
+(defun mode-line-bell-begin-flash ()
+  "Begin flashing the mode line."
+  (unless mode-line-bell-flashing
+    (invert-face 'mode-line)
+    (setq mode-line-bell-flashing t)))
+
+(defun mode-line-bell-end-flash ()
+  "Finish flashing the mode line."
+  (when mode-line-bell-flashing
+    (invert-face 'mode-line)
+    (setq mode-line-bell-flashing nil)))
+
 ;;;###autoload
 (defun mode-line-bell-flash ()
   "Flash the mode line momentarily."
-  (invert-face 'mode-line)
-  (run-with-timer 0.05 nil 'invert-face 'mode-line))
-
+  (unless mode-line-bell-flashing
+    (run-with-timer 0.05 nil 'mode-line-bell-end-flash)
+    (mode-line-bell-begin-flash)))
 
 ;;;###autoload
 (define-minor-mode mode-line-bell-mode


### PR DESCRIPTION
The main improvement here is to prevent weird behavior when the bell rings while the mode line is already flashing. Sometimes this could leave the mode line permanently inverted, and this couldn't be trivially fixed since there was no variable storing which face inversion was the original and which was the "flash" state. I fixed this by adding a state variable that tracks when the mode line is flashing and prevents initiating additional flashes until the first flash is done.

In addition, I extracted the flash time into a variable to make it easier to customize.