### PR TITLE
Remap mode-line face instead of inverting it

### DIFF
--- a/mode-line-bell.el
+++ b/mode-line-bell.el
@@ -1,10 +1,12 @@
 ;;; mode-line-bell.el --- Flash the mode line instead of ringing the bell  -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2021  Case Duckworth
 ;; Copyright (C) 2018  Steve Purcell
 
 ;; Author: Steve Purcell <steve@sanityinc.com>
+;; Author: Case Duckworth <acdw@acdw.net>
 ;; Keywords: convenience
-;; URL: https://github.com/purcell/mode-line-bell
+;; URL: https://github.com/duckwork/mode-line-bell
 ;; Package-Version: 0.2
 ;; Package-Requires: ((emacs "26.2"))
 

--- a/mode-line-bell.el
+++ b/mode-line-bell.el
@@ -4,6 +4,9 @@
 
 ;; Author: Steve Purcell <steve@sanityinc.com>
 ;; Keywords: convenience
+;; URL: https://github.com/purcell/mode-line-bell
+;; Package-Version: 0.2
+;; Package-Requires: ((emacs "26.2"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/mode-line-bell.el
+++ b/mode-line-bell.el
@@ -52,7 +52,7 @@
 
 (defun mode-line-bell--init (&rest _)
   "Initialize `mode-line-orig' for when the bell rings."
-  (copy-face 'mode-line 'mode-line-orig))
+  (copy-face 'mode-line 'mode-line-orig (selected-frame)))
 
 (defun mode-line-bell--remap ()
   "Remap the mode-line face to mode-line-bell."
@@ -90,10 +90,10 @@
   (if mode-line-bell-mode
       (progn (advice-add #'load-theme :after #'mode-line-bell--init)
               (add-function :after after-focus-change-function
-                            #'mode-line-bell--unremap))
+                            #'mode-line-bell--init))
     (advice-remove #'load-theme #'mode-line-bell--init)
     (remove-function after-focus-change-function
-                     #'mode-line-bell--unremap)))
+                     #'mode-line-bell--init)))
 
 (provide 'mode-line-bell)
 ;;; mode-line-bell.el ends here


### PR DESCRIPTION

There are times, when running an Emacs server, that a new frame incorrectly has
an inverted mode-line face.  I think it has to do with a race condition when
inverting the face.

To correct this issue, I've added a face `mode-line-bell`, which inherits from
the `mode-line` face and inverts the video. `mode-line-flash` now adds and
removes that face from `face-remapping-alist`, and the `mode-line-bell-mode`
also adds a function to `after-focus-change-function` to recover the correct
mode-line face.

The main issue with this correction is that the inverse-video property on
`mode-line-bell` behaves slightly differently than the previous functionality of
this mode.  Suggestions on how to solve this are welcome -- as far as I can
guess, the best way to do that would be to hook the defface call into changing
themes, which is clunky.